### PR TITLE
feat: add auth provider context and hook

### DIFF
--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { createClient, Session, User } from '@supabase/supabase-js';
+
+// Initialize Supabase client using env vars.
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+interface AuthContextType {
+  user: User | null;
+  session: Session | null;
+  signIn: typeof supabase.auth.signInWithPassword;
+  signOut: typeof supabase.auth.signOut;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    // Fetch initial session on mount
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session);
+      setUser(data.session?.user ?? null);
+    });
+
+    // Listen for changes on auth state (sign in, sign out, etc.)
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const value: AuthContextType = {
+    user,
+    session,
+    signIn: (credentials) => supabase.auth.signInWithPassword(credentials),
+    signOut: () => supabase.auth.signOut(),
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = (): AuthContextType => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+


### PR DESCRIPTION
## Summary
- add `AuthProvider` to expose Supabase auth session and helpers via React context
- expose `useAuth` hook for consuming user and sign-in/sign-out functions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b2f59328832895ee17d2bbb10a30