### PR TITLE
feat: add Supabase auth pages

### DIFF
--- a/src/auth/pages/ForgotPassword.tsx
+++ b/src/auth/pages/ForgotPassword.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Alert, Box, Button, TextField } from '@mui/material';
+import { supabase } from '../../lib/supabaseClient';
+
+const ForgotPassword: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(false);
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/auth/reset-password`,
+    });
+    if (error) setError(error.message);
+    else setSuccess(true);
+  };
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{ display: 'flex', flexDirection: 'column', gap: 2, width: 300 }}
+    >
+      {success && <Alert severity="success">Password reset email sent.</Alert>}
+      {error && <Alert severity="error">{error}</Alert>}
+      <TextField
+        label="Email"
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        fullWidth
+      />
+      <Button type="submit" variant="contained">
+        Send Reset Email
+      </Button>
+    </Box>
+  );
+};
+
+export default ForgotPassword;
+

--- a/src/auth/pages/ResetPassword.tsx
+++ b/src/auth/pages/ResetPassword.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Alert, Box, Button, TextField } from '@mui/material';
+import { supabase } from '../../lib/supabaseClient';
+
+const ResetPassword: React.FC = () => {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(false);
+    const { error } = await supabase.auth.updateUser({ password });
+    if (error) setError(error.message);
+    else setSuccess(true);
+  };
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{ display: 'flex', flexDirection: 'column', gap: 2, width: 300 }}
+    >
+      {success && <Alert severity="success">Password updated.</Alert>}
+      {error && <Alert severity="error">{error}</Alert>}
+      <TextField
+        label="New Password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+        fullWidth
+      />
+      <Button type="submit" variant="contained">
+        Set Password
+      </Button>
+    </Box>
+  );
+};
+
+export default ResetPassword;
+

--- a/src/auth/pages/SignIn.tsx
+++ b/src/auth/pages/SignIn.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { Alert, Box, Button, Link, Stack, TextField } from '@mui/material';
+import { supabase } from '../../lib/supabaseClient';
+
+const SignIn: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) setError(error.message);
+    setLoading(false);
+  };
+
+  const handleGoogleSignIn = async () => {
+    const { error } = await supabase.auth.signInWithOAuth({ provider: 'google' });
+    if (error) setError(error.message);
+  };
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{ display: 'flex', flexDirection: 'column', gap: 2, width: 300 }}
+    >
+      {error && <Alert severity="error">{error}</Alert>}
+      <TextField
+        label="Email"
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        fullWidth
+      />
+      <TextField
+        label="Password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+        fullWidth
+      />
+      <Button type="submit" variant="contained" disabled={loading}>
+        Sign In
+      </Button>
+      <Button variant="outlined" onClick={handleGoogleSignIn}>
+        Sign in with Google
+      </Button>
+      <Stack direction="row" justifyContent="space-between">
+        <Link href="/auth/sign-up">Sign Up</Link>
+        <Link href="/auth/forgot-password">Forgot Password?</Link>
+      </Stack>
+    </Box>
+  );
+};
+
+export default SignIn;
+

--- a/src/auth/pages/SignUp.tsx
+++ b/src/auth/pages/SignUp.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { Alert, Box, Button, TextField } from '@mui/material';
+import { supabase } from '../../lib/supabaseClient';
+
+const SignUp: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(false);
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+    });
+    if (error) setError(error.message);
+    else setSuccess(true);
+  };
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{ display: 'flex', flexDirection: 'column', gap: 2, width: 300 }}
+    >
+      {success && (
+        <Alert severity="success">Check your email to confirm your account.</Alert>
+      )}
+      {error && <Alert severity="error">{error}</Alert>}
+      <TextField
+        label="Email"
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        fullWidth
+      />
+      <TextField
+        label="Password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+        fullWidth
+      />
+      <Button type="submit" variant="contained">
+        Sign Up
+      </Button>
+    </Box>
+  );
+};
+
+export default SignUp;
+

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+


### PR DESCRIPTION
## Summary
- add Supabase client helper
- create Sign In, Sign Up, Forgot Password, and Reset Password pages with MUI forms

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b2fc1e588328a422219f7cd1aa46