### PR TITLE
Add AppShell routing and placeholder pages

### DIFF
--- a/src/pages/Ads.tsx
+++ b/src/pages/Ads.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Ads: React.FC = () => {
+  return (
+    <div>
+      <h1>Ads</h1>
+    </div>
+  );
+};
+
+export default Ads;

--- a/src/pages/AppShell.tsx
+++ b/src/pages/AppShell.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
+import BottomNavigation from '@mui/material/BottomNavigation';
+import BottomNavigationAction from '@mui/material/BottomNavigationAction';
+
+import P2P from './P2P';
+import Orders from './Orders';
+import Ads from './Ads';
+import Profile from './Profile';
+
+const Navigation: React.FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [value, setValue] = React.useState(location.pathname);
+
+  React.useEffect(() => {
+    setValue(location.pathname);
+  }, [location.pathname]);
+
+  const handleChange = (_event: React.SyntheticEvent, newValue: string) => {
+    setValue(newValue);
+    navigate(newValue);
+  };
+
+  return (
+    <BottomNavigation value={value} onChange={handleChange} showLabels>
+      <BottomNavigationAction label="P2P" value="/p2p" />
+      <BottomNavigationAction label="Orders" value="/orders" />
+      <BottomNavigationAction label="Ads" value="/ads" />
+      <BottomNavigationAction label="Profile" value="/profile" />
+    </BottomNavigation>
+  );
+};
+
+const AppShell: React.FC = () => {
+  return (
+    <Router>
+      <Routes>
+        <Route path="/" element={<Navigate to="/p2p" replace />} />
+        <Route path="/p2p" element={<P2P />} />
+        <Route path="/orders" element={<Orders />} />
+        <Route path="/ads" element={<Ads />} />
+        <Route path="/profile" element={<Profile />} />
+      </Routes>
+      <Navigation />
+    </Router>
+  );
+};
+
+export default AppShell;

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Orders: React.FC = () => {
+  return (
+    <div>
+      <h1>Orders</h1>
+    </div>
+  );
+};
+
+export default Orders;

--- a/src/pages/P2P.tsx
+++ b/src/pages/P2P.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const P2P: React.FC = () => {
+  return (
+    <div>
+      <h1>P2P</h1>
+    </div>
+  );
+};
+
+export default P2P;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Profile: React.FC = () => {
+  return (
+    <div>
+      <h1>Profile</h1>
+    </div>
+  );
+};
+
+export default Profile;


### PR DESCRIPTION
## Summary
- Add AppShell component with router routes for P2P, Orders, Ads, and Profile tabs
- Implement MUI BottomNavigation for mobile tab switching
- Provide placeholder pages for P2P, Orders, Ads, and Profile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b2ff9bf88328b296a06e690d4083