### PR TITLE
Add Profile component with email display and sign-out

### DIFF
--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -1,0 +1,18 @@
+import React, { useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
+import { supabase } from '../supabase';
+
+export default function Profile() {
+  const { user } = useContext(AuthContext);
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut();
+  };
+
+  return (
+    <div>
+      <p>{user?.email}</p>
+      <button onClick={handleSignOut}>Sign Out</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Profile component reading user from AuthContext and rendering email
- include Sign Out button wired to supabase.auth.signOut

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b303b74c83288b3ea7ccaa764639