### PR TITLE
feat(auth): finalize routes, redirects, Google, validation, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,50 @@
 # Bybit Bot Auth App
 
-This project is a React + TypeScript application bootstrapped with Vite. It implements authentication using Supabase and Material UI.
+Minimal authentication demo using Vite, React, MUI and Supabase.
 
-## Environment Variables
+## Setup
 
-Create a `.env` file in the project root with the following keys:
+- Node.js 20
+- Install deps: `npm install`
+- Run dev server: `npm run dev`
+
+## Environment variables
+
+Create a `.env` file (see `.env.example`):
 
 ```
-VITE_SUPABASE_URL=
-VITE_SUPABASE_ANON_KEY=
-VITE_SITE_URL=http://localhost:5173
+VITE_SUPABASE_URL="https://your-project.supabase.co"   # Supabase project URL
+VITE_SUPABASE_ANON_KEY="public-anon-key"               # Supabase anon key
+VITE_SITE_URL="http://localhost:5173"                  # Base site URL used for redirects
 ```
 
-See `.env.example` for reference.
+### Supabase configuration
 
-## Installation
+- Auth -> URL Configuration: set **Site URL** to `VITE_SITE_URL`.
+- Auth -> Providers: enable **Google** and set redirect URL to `VITE_SITE_URL/auth/reset-password`.
 
-Install dependencies:
+## Auth flows
 
-```bash
-npm install
+- Email/password sign up with validation and confirm password.
+- Email/password sign in, redirecting to the previous page or `/profile`.
+- Google OAuth on both Sign In and Sign Up.
+- Forgot/Reset password handled via `/auth/reset-password`.
+- Sign out returns to `/auth/sign-in`.
+- Supabase links Google and password accounts by email; if a provider conflict error appears, sign in with the original method first and then try Google.
+
+## Manual test checklist
+
+- [ ] Unauthed user visiting `/profile` is redirected to `/auth/sign-in` and after sign-in lands on `/profile`.
+- [ ] Sign Up: mismatched passwords show inline error; valid sign-up follows email confirmation setting.
+- [ ] Sign In (password): invalid credentials show error; valid credentials navigate to `/profile`.
+- [ ] Sign In (Google): works from Sign In and Sign Up and returns to previous page or `/profile`.
+- [ ] Forgot/Reset: reset email is sent and new password allows login.
+- [ ] Sign Out: redirects to `/auth/sign-in`.
+- [ ] Bottom nav visible only when authed and reflects current tab.
+- [ ] Missing env keys produce a clear error.
+
+## Production build
+
 ```
-
-## Development
-
-Run the development server:
-
-```bash
-npm run dev
-```
-
-## Production Build
-
-Create an optimized build for production deployment:
-
-```bash
 npm run build
 ```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import SignIn from './auth/pages/SignIn';
 import SignUp from './auth/pages/SignUp';
 import ForgotPassword from './auth/pages/ForgotPassword';
@@ -9,6 +9,7 @@ import AppShell from './pages/AppShell';
 const App = () => {
   return (
     <Routes>
+      <Route path="/auth" element={<Navigate to="/auth/sign-in" replace />} />
       <Route path="/auth/sign-in" element={<SignIn />} />
       <Route path="/auth/sign-up" element={<SignUp />} />
       <Route path="/auth/forgot-password" element={<ForgotPassword />} />

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1,31 +1,30 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
-import type { Session, User } from '@supabase/supabase-js';
+import type { User } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabaseClient';
 
 interface AuthContextType {
   user: User | null;
-  session: Session | null;
-  signIn: typeof supabase.auth.signInWithPassword;
+  loading: boolean;
   signOut: typeof supabase.auth.signOut;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data }) => {
-      setSession(data.session);
       setUser(data.session?.user ?? null);
+      setLoading(false);
     });
 
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session);
       setUser(session?.user ?? null);
+      setLoading(false);
     });
 
     return () => {
@@ -35,8 +34,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const value: AuthContextType = {
     user,
-    session,
-    signIn: (credentials) => supabase.auth.signInWithPassword(credentials),
+    loading,
     signOut: () => supabase.auth.signOut(),
   };
 

--- a/src/auth/pages/ForgotPassword.tsx
+++ b/src/auth/pages/ForgotPassword.tsx
@@ -1,21 +1,25 @@
 import React, { useState } from 'react';
-import { Alert, Box, Button, TextField } from '@mui/material';
+import { Alert, Box, Button, Link, TextField } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
 import { supabase } from '../../lib/supabaseClient';
 
 const ForgotPassword: React.FC = () => {
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
     setSuccess(false);
+    setLoading(true);
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
       redirectTo: `${import.meta.env.VITE_SITE_URL}/auth/reset-password`,
     });
     if (error) setError(error.message);
     else setSuccess(true);
+    setLoading(false);
   };
 
   return (
@@ -34,9 +38,12 @@ const ForgotPassword: React.FC = () => {
         required
         fullWidth
       />
-      <Button type="submit" variant="contained">
+      <Button type="submit" variant="contained" disabled={loading}>
         Send Reset Email
       </Button>
+      <Link component={RouterLink} to="/auth/sign-in" textAlign="center">
+        Back to Sign In
+      </Link>
     </Box>
   );
 };

--- a/src/auth/pages/ResetPassword.tsx
+++ b/src/auth/pages/ResetPassword.tsx
@@ -1,20 +1,74 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Alert, Box, Button, TextField } from '@mui/material';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { supabase } from '../../lib/supabaseClient';
+import { useAuth } from '../AuthProvider';
 
 const ResetPassword: React.FC = () => {
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [passwordError, setPasswordError] = useState('');
+  const [confirmError, setConfirmError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user } = useAuth();
+
+  const searchParams = new URLSearchParams(location.search);
+  const hashParams = new URLSearchParams(location.hash.startsWith('#') ? location.hash.slice(1) : '');
+  const type = searchParams.get('type') || hashParams.get('type');
+
+  useEffect(() => {
+    if (type !== 'recovery' && user) {
+      const redirectPath = sessionStorage.getItem('redirectPath');
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        navigate(redirectPath, { replace: true });
+      } else {
+        navigate('/profile', { replace: true });
+      }
+    }
+  }, [type, user, navigate]);
+
+  const validate = () => {
+    let valid = true;
+    if (password.length < 8) {
+      setPasswordError('Password must be at least 8 characters');
+      valid = false;
+    } else {
+      setPasswordError('');
+    }
+
+    if (confirmPassword !== password) {
+      setConfirmError('Passwords do not match');
+      valid = false;
+    } else {
+      setConfirmError('');
+    }
+
+    return valid;
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!validate()) return;
+    setLoading(true);
     setError(null);
-    setSuccess(false);
     const { error } = await supabase.auth.updateUser({ password });
-    if (error) setError(error.message);
-    else setSuccess(true);
+    if (error) {
+      setError(error.message);
+    } else {
+      setSuccess(true);
+      setTimeout(() => navigate('/auth/sign-in', { replace: true }), 1500);
+    }
+    setLoading(false);
   };
+
+  if (type !== 'recovery') {
+    return null;
+  }
 
   return (
     <Box
@@ -31,8 +85,20 @@ const ResetPassword: React.FC = () => {
         onChange={(e) => setPassword(e.target.value)}
         required
         fullWidth
+        error={!!passwordError}
+        helperText={passwordError}
       />
-      <Button type="submit" variant="contained">
+      <TextField
+        label="Confirm Password"
+        type="password"
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+        required
+        fullWidth
+        error={!!confirmError}
+        helperText={confirmError}
+      />
+      <Button type="submit" variant="contained" disabled={loading}>
         Set Password
       </Button>
     </Box>
@@ -40,4 +106,3 @@ const ResetPassword: React.FC = () => {
 };
 
 export default ResetPassword;
-

--- a/src/auth/pages/SignIn.tsx
+++ b/src/auth/pages/SignIn.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Alert, Box, Button, Link, Stack, TextField } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useLocation, useNavigate, type Location } from 'react-router-dom';
 import { supabase } from '../../lib/supabaseClient';
 
 const SignIn: React.FC = () => {
@@ -8,25 +8,55 @@ const SignIn: React.FC = () => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [emailError, setEmailError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
   const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as { from?: Location } | undefined)?.from?.pathname || '/profile';
+
+  const validate = () => {
+    let valid = true;
+    if (!email) {
+      setEmailError('Email is required');
+      valid = false;
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setEmailError('Invalid email');
+      valid = false;
+    } else {
+      setEmailError('');
+    }
+
+    if (password.length < 8) {
+      setPasswordError('Password must be at least 8 characters');
+      valid = false;
+    } else {
+      setPasswordError('');
+    }
+    return valid;
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!validate()) return;
     setLoading(true);
     setError(null);
     const { error } = await supabase.auth.signInWithPassword({
       email,
       password,
     });
-    if (error) setError(error.message);
-    else navigate('/');
+    if (error) {
+      setError(error.message);
+    } else {
+      navigate(from, { replace: true });
+    }
     setLoading(false);
   };
 
   const handleGoogleSignIn = async () => {
+    sessionStorage.setItem('redirectPath', from);
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
-      options: { redirectTo: import.meta.env.VITE_SITE_URL },
+      options: { redirectTo: `${import.meta.env.VITE_SITE_URL}/auth/reset-password` },
     });
     if (error) setError(error.message);
   };
@@ -45,6 +75,8 @@ const SignIn: React.FC = () => {
         onChange={(e) => setEmail(e.target.value)}
         required
         fullWidth
+        error={!!emailError}
+        helperText={emailError}
       />
       <TextField
         label="Password"
@@ -53,16 +85,22 @@ const SignIn: React.FC = () => {
         onChange={(e) => setPassword(e.target.value)}
         required
         fullWidth
+        error={!!passwordError}
+        helperText={passwordError}
       />
       <Button type="submit" variant="contained" disabled={loading}>
         Sign In
       </Button>
-      <Button variant="outlined" onClick={handleGoogleSignIn}>
-        Sign in with Google
+      <Button variant="outlined" onClick={handleGoogleSignIn} disabled={loading}>
+        Continue with Google
       </Button>
       <Stack direction="row" justifyContent="space-between">
-        <Link href="/auth/sign-up">Sign Up</Link>
-        <Link href="/auth/forgot-password">Forgot Password?</Link>
+        <Link component={RouterLink} to="/auth/sign-up" state={{ from: location.state?.from }}>
+          Sign Up
+        </Link>
+        <Link component={RouterLink} to="/auth/forgot-password">
+          Forgot Password?
+        </Link>
       </Stack>
     </Box>
   );

--- a/src/auth/pages/SignUp.tsx
+++ b/src/auth/pages/SignUp.tsx
@@ -1,23 +1,79 @@
 import React, { useState } from 'react';
 import { Alert, Box, Button, Link, Stack, TextField } from '@mui/material';
+import { Link as RouterLink, useLocation, useNavigate, type Location } from 'react-router-dom';
 import { supabase } from '../../lib/supabaseClient';
 
 const SignUp: React.FC = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [emailError, setEmailError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+  const [confirmError, setConfirmError] = useState('');
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as { from?: Location } | undefined)?.from?.pathname || '/profile';
+
+  const validate = () => {
+    let valid = true;
+    if (!email) {
+      setEmailError('Email is required');
+      valid = false;
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setEmailError('Invalid email');
+      valid = false;
+    } else {
+      setEmailError('');
+    }
+
+    if (password.length < 8) {
+      setPasswordError('Password must be at least 8 characters');
+      valid = false;
+    } else {
+      setPasswordError('');
+    }
+
+    if (confirmPassword !== password) {
+      setConfirmError('Passwords do not match');
+      valid = false;
+    } else {
+      setConfirmError('');
+    }
+
+    return valid;
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!validate()) return;
+    setLoading(true);
     setError(null);
     setSuccess(false);
-    const { error } = await supabase.auth.signUp({
+    const { data, error } = await supabase.auth.signUp({
       email,
       password,
+      options: { emailRedirectTo: `${import.meta.env.VITE_SITE_URL}/auth/reset-password` },
+    });
+    if (error) {
+      setError(error.message);
+    } else if (data.session) {
+      navigate(from, { replace: true });
+    } else {
+      setSuccess(true);
+    }
+    setLoading(false);
+  };
+
+  const handleGoogleSignUp = async () => {
+    sessionStorage.setItem('redirectPath', from);
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: `${import.meta.env.VITE_SITE_URL}/auth/reset-password` },
     });
     if (error) setError(error.message);
-    else setSuccess(true);
   };
 
   return (
@@ -37,6 +93,8 @@ const SignUp: React.FC = () => {
         onChange={(e) => setEmail(e.target.value)}
         required
         fullWidth
+        error={!!emailError}
+        helperText={emailError}
       />
       <TextField
         label="Password"
@@ -45,12 +103,29 @@ const SignUp: React.FC = () => {
         onChange={(e) => setPassword(e.target.value)}
         required
         fullWidth
+        error={!!passwordError}
+        helperText={passwordError}
       />
-      <Button type="submit" variant="contained">
+      <TextField
+        label="Confirm Password"
+        type="password"
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+        required
+        fullWidth
+        error={!!confirmError}
+        helperText={confirmError}
+      />
+      <Button type="submit" variant="contained" disabled={loading}>
         Sign Up
       </Button>
+      <Button variant="outlined" onClick={handleGoogleSignUp} disabled={loading}>
+        Continue with Google
+      </Button>
       <Stack direction="row" justifyContent="flex-end">
-        <Link href="/auth/sign-in">Sign In</Link>
+        <Link component={RouterLink} to="/auth/sign-in" state={{ from: location.state?.from }}>
+          Sign In
+        </Link>
       </Stack>
     </Box>
   );

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_ANON_KEY: string;
+  readonly VITE_SITE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase environment variables');
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,10 +7,10 @@ import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <AuthProvider>
-      <BrowserRouter>
+    <BrowserRouter>
+      <AuthProvider>
         <App />
-      </BrowserRouter>
-    </AuthProvider>
+      </AuthProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { Box, Button, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../auth/AuthProvider';
 
 const Profile: React.FC = () => {
   const { user, signOut } = useAuth();
+  const navigate = useNavigate();
 
   const handleSignOut = async () => {
     await signOut();
+    navigate('/auth/sign-in', { replace: true });
   };
 
   return (

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../auth/AuthProvider';
 
 interface Props {
@@ -7,10 +7,15 @@ interface Props {
 }
 
 const ProtectedRoute: React.FC<Props> = ({ children }) => {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) return null;
+
   if (!user) {
-    return <Navigate to="/auth/sign-in" replace />;
+    return <Navigate to="/auth/sign-in" state={{ from: location }} replace />;
   }
+
   return children;
 };
 


### PR DESCRIPTION
## Summary
- validate Supabase env vars and initialize client safely
- add AuthProvider with session sync and route guard preserving redirects
- implement full email/Google auth pages with validation and password reset
- document env setup, Supabase config and manual testing steps

## Testing
- `npm run build`

## Manual Test Checklist
- [ ] Unauthed user visiting `/profile` is redirected to sign-in and returns to `/profile` after login
- [ ] Sign Up: mismatched passwords show inline error; valid sign-up follows email confirmation setting
- [ ] Sign In (password): invalid credentials show error; valid credentials navigate to `/profile`
- [ ] Sign In (Google): works from Sign In and Sign Up and returns to previous page or `/profile`
- [ ] Forgot/Reset: reset email is sent and new password allows login
- [ ] Sign Out: redirects to `/auth/sign-in`
- [ ] Bottom nav visible only when authed and reflects current tab
- [ ] Missing env keys produce a clear error

## Supabase settings required
- Set **Site URL** to `VITE_SITE_URL`
- Enable **Google** provider with redirect URL `VITE_SITE_URL/auth/reset-password`

## Known limitations
- Supabase may show provider/email conflict errors when attempting to link identities; users should sign in with the original method first and then try Google


------
https://chatgpt.com/codex/tasks/task_e_6897d7ae7ff0832897704bb68ebb1600